### PR TITLE
Update Node.js version to 20.x in CI workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '20.x'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
     


### PR DESCRIPTION
The build-and-publish GitHub Actions workflow now uses Node.js 20.x instead of 18.x to ensure compatibility with the latest Node features and security updates.

## Summary by Sourcery

CI:
- Use Node.js 20.x in the build-and-publish GitHub Actions workflow instead of 18.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and publish pipeline to use a newer runtime version, aligning with current platform standards.
  * Ensures continued compatibility, security updates, and more predictable builds for future releases.
  * No changes to product functionality, interfaces, or performance.
  * No action required from users; existing workflows and usage remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->